### PR TITLE
Update kdtree2.cpp

### DIFF
--- a/src-c++/kdtree2.cpp
+++ b/src-c++/kdtree2.cpp
@@ -174,26 +174,12 @@ KDTreeNode* KDTree::build_tree_for_range(int l, int u, KDTreeNode* parent) {
     // now, c is the identity of which coordinate has the greatest spread
     //
 
-    if (false) {
-      m = (l+u)/2;
-      select_on_coordinate(c,m,l,u);  
-    } else {
-      float sum; 
-      float average;
-
-      if (true) {
-	sum = 0.0;
-	for (int k=l; k <= u; k++) {
-	  sum += the_data[ind[k]][c];
-	}
-	average = sum / static_cast<float> (u-l+1);
-      } else {
-	// average of top and bottom nodes.
-	average = (node->box[c].upper + node->box[c].lower)*0.5; 
-      }
-	
-      m = select_on_coordinate_value(c,average,l,u);
+    double average=0;
+    for (int k=l; k <= u; k++) {
+      average += the_data[ind[k]][c];
     }
+    average /= (u-l+1);
+    m = select_on_coordinate_value(c,average,l,u);
 
 
     // move the indices around to cut on dim 'c'.


### PR DESCRIPTION
This fixes a bug that causes tree creation to fail for more than about one million points (for me, it failed when using 4004000 points).  Using a single precision variable to sum this many points causes loss of precision (i.e., eventually all but the most significant one or two digits of each new value added to the sum are lost).  The solution is to simply use a double precision float for the sum variable.
